### PR TITLE
feat: bump polars 0.53 -> 0.55.2

### DIFF
--- a/anndata-hdf5/Cargo.toml
+++ b/anndata-hdf5/Cargo.toml
@@ -17,6 +17,11 @@ itertools = "0.14"
 hdf5 = { package = "hdf5-metno", version = "0.12.3", features = ["blosc", "blosc-zstd"] }
 blosc-src = { version = "0.3.0", features = ["zstd"] }
 hdf5-sys = { package = "hdf5-metno-sys", version = "0.11", features = ["static", "zlib", "threadsafe"] }
+# hdf5-metno-src 0.10.3 vendors HDF5 2.2.0, whose version string hdf5-metno-sys
+# 0.11.x rejects outright (`Invalid H5_VERSION: "2.2.0"`). Because `-src` is only
+# a `^0.10` dependency of `-sys`, a fresh resolution picks it up and this crate
+# stops building. Pin until the `-sys` requirement can move to ^0.12.
+hdf5-src = { package = "hdf5-metno-src", version = "=0.10.2" }
 libz-sys = { version = "1", features = ["libc"], default-features = false }
 ndarray = "0.17"
 

--- a/anndata/Cargo.toml
+++ b/anndata/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.14"
 ndarray = "0.17"
 nalgebra-sparse = "0.11"
 num = "0.4"
-polars = { version = "0.53", features = ["lazy", "ndarray", "dtype-full"] }
+polars = { version = "0.55.2", features = ["lazy", "ndarray", "dtype-full"] }
 paste = "1.0"
 parking_lot = "0.12"
 smallvec = "1.15"

--- a/anndata/src/anndata/dataset.rs
+++ b/anndata/src/anndata/dataset.rs
@@ -476,7 +476,7 @@ impl<B: Backend> StackedAnnData<B> {
 
 fn as_str_vec(series: &Column) -> Vec<String> {
     if let Ok(s) = series.str() {
-        s.into_iter()
+        s.iter()
             .map(|x| x.unwrap().to_string())
             .collect::<Vec<_>>()
     } else {

--- a/anndata/src/data/array/dataframe.rs
+++ b/anndata/src/data/array/dataframe.rs
@@ -364,27 +364,27 @@ fn write_column<B: Backend, G: GroupOp<B>>(
     name: &str,
 ) -> Result<DataContainer<B>> {
     match series.dtype() {
-        DataType::UInt8 => write_series_helper(series.u8()?, location, name),
-        DataType::UInt16 => write_series_helper(series.u16()?, location, name),
-        DataType::UInt32 => write_series_helper(series.u32()?, location, name),
-        DataType::UInt64 => write_series_helper(series.u64()?, location, name),
-        DataType::Int8 => write_series_helper(series.i8()?, location, name),
-        DataType::Int16 => write_series_helper(series.i16()?, location, name),
-        DataType::Int32 => write_series_helper(series.i32()?, location, name),
-        DataType::Int64 => write_series_helper(series.i64()?, location, name),
+        DataType::UInt8 => write_series_helper(series.u8()?.iter(), location, name),
+        DataType::UInt16 => write_series_helper(series.u16()?.iter(), location, name),
+        DataType::UInt32 => write_series_helper(series.u32()?.iter(), location, name),
+        DataType::UInt64 => write_series_helper(series.u64()?.iter(), location, name),
+        DataType::Int8 => write_series_helper(series.i8()?.iter(), location, name),
+        DataType::Int16 => write_series_helper(series.i16()?.iter(), location, name),
+        DataType::Int32 => write_series_helper(series.i32()?.iter(), location, name),
+        DataType::Int64 => write_series_helper(series.i64()?.iter(), location, name),
         DataType::Float32 => series
             .f32()?
-            .into_iter()
+            .iter()
             .map(|x| x.unwrap_or(f32::NAN))
             .collect::<Array1<f32>>()
             .write(location, name),
         DataType::Float64 => series
             .f64()?
-            .into_iter()
+            .iter()
             .map(|x| x.unwrap_or(f64::NAN))
             .collect::<Array1<f64>>()
             .write(location, name),
-        DataType::Boolean => write_series_helper(series.bool()?, location, name),
+        DataType::Boolean => write_series_helper(series.bool()?.iter(), location, name),
         DataType::String => {
             let series = series.str()?;
             if let Some(str_vec) = series
@@ -395,7 +395,7 @@ fn write_column<B: Backend, G: GroupOp<B>>(
                 Array1::from(str_vec).write(location, name)
             } else {
                 series
-                    .into_iter()
+                    .iter()
                     .collect::<CategoricalArray>()
                     .write(location, name)
             }

--- a/pyanndata/Cargo.toml
+++ b/pyanndata/Cargo.toml
@@ -16,18 +16,18 @@ anndata = { version = "0.7.0", path = "../anndata" }
 anndata-hdf5 = { version = "0.5.3", path = "../anndata-hdf5" }
 anyhow = "1.0"
 downcast-rs = "2"
-numpy = "0.27"
+numpy = "0.29"
 ndarray = "0.17"
 nalgebra-sparse = "0.11"
 hdf5 = { package = "hdf5-metno", version = "0.12" }
-polars = { version = "0.53", features = ["ndarray"] }
-pyo3-polars = {version = "0.26", features = ["dtype-full", "dtype-struct"] }
+polars = { version = "0.55.2", features = ["ndarray"] }
+pyo3-polars = {version = "0.28", features = ["dtype-full", "dtype-struct"] }
 rand = "0.9"
 flate2 = "1.0"
 rayon = "1.11"
 
 [dependencies.pyo3]
-version = "0.27"
+version = "0.29"
 features = ["multiple-pymethods", "anyhow"]
 
 [features]

--- a/pyanndata/src/anndata/backed.rs
+++ b/pyanndata/src/anndata/backed.rs
@@ -1111,7 +1111,7 @@ impl<B: Backend> AnnDataTrait for InnerAnnData<B> {
             let obs = inner.read_obs()?;
             obs.column(&key)?
                 .str()?
-                .into_iter()
+                .iter()
                 .map(|x| x.map(|s| s.to_string()))
                 .collect()
         } else {

--- a/pyanndata/src/anndata/dataset.rs
+++ b/pyanndata/src/anndata/dataset.rs
@@ -814,7 +814,7 @@ impl<B: Backend> AnnDataSetTrait for Slot<anndata::AnnDataSet<B>> {
             let obs = inner.read_obs()?;
             obs.column(&key)?
                 .str()?
-                .into_iter()
+                .iter()
                 .map(|x| x.map(|s| s.to_string()))
                 .collect()
         } else {

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["data"]
 
 [dependencies]
 pyanndata = { version = "0.7.1", path = "../pyanndata" }
-pyo3-log = "0.13"
+pyo3-log = "0.13.4"
 
 [dependencies.pyo3]
-version = "0.27"
+version = "0.29"
 features = ["multiple-pymethods"]
 
 [features]


### PR DESCRIPTION
Closes #39.

> **Stacked on #40.** The first commit here is that PR's one-line build fix, without which `anndata-hdf5` does not compile at all and CI cannot go green. Merge #40 first and I will rebase, or take both together — the polars work is the second commit.

## Why

`polars` is pre-1.0, so each minor release is a distinct, incompatible set of types. `anndata` takes and returns `polars::prelude::DataFrame` across its public API but does not re-export `polars`, so every downstream crate must declare a `polars` dependency matching this one *exactly*. That means this pin decides the polars version for the whole downstream ecosystem, and it is currently two minor versions behind.

## What changed

| crate | from | to | why |
|---|---|---|---|
| `polars` | 0.53 | 0.55.2 | the actual goal |
| `pyo3-polars` | 0.26 | 0.28 | first release supporting polars 0.55 |
| `pyo3` | 0.27 | 0.29 | required by `pyo3-polars` 0.28 |
| `numpy` | 0.27 | 0.29 | tracks `pyo3` in lockstep |
| `pyo3-log` | 0.13 | 0.13.4 | earlier releases cap at `pyo3 < 0.29` |

Two things worth knowing:

* The requirement has to be **`0.55.2`, not `0.55`**. polars 0.55.0 declares `arrow = "^0.55.0"` and `polars-parquet = "^0.55.0"`, but `polars-parquet` 0.55.2 requires `polars-arrow ^0.55.2`, so a resolution that picks 0.55.0 fails with `failed to select a version for polars-arrow`.
* **`pyo3` 0.29 required no source changes.** The bump is purely a manifest change on that side.

The only code change is that polars 0.55 removed `impl IntoIterator for &ChunkedArray<T>`, so `.into_iter()` on a borrowed `ChunkedArray` becomes `.iter()`. Same items (`Option<T>`), same semantics. 14 call sites:

* `anndata/src/data/array/dataframe.rs` (11)
* `anndata/src/anndata/dataset.rs` (1)
* `pyanndata/src/anndata/backed.rs` (1)
* `pyanndata/src/anndata/dataset.rs` (1)

## Verified

```
cargo check --workspace                                  # clean
cargo test -p anndata -p anndata-hdf5 -p anndata-zarr    # 19 passed; 0 failed
```

rustc 1.97.1, x86_64-unknown-linux-gnu, Python 3.13.7, cmake 3.29.2.

I have not exercised the Python test suite — I could only get as far as compiling `pyanndata` and `anndata_rs` — so a look from someone who can run the bindings end-to-end would be worthwhile before merging.

## Separately worth considering

Not included here, but it would retire this whole class of problem for downstreams:

```rust
pub use nalgebra_sparse;
pub use polars;
```

Consumers could then use `anndata::polars::prelude::DataFrame` and be structurally unable to resolve a mismatched version, instead of hand-shadowing this crate's choices and re-checking them each release. Both types already cross the public API boundary (`DataFrame` via `set_obs`/`set_var`, `CsrMatrix` via `DynCsrMatrix`). Happy to add it here or in a follow-up if you want it.