### PR TITLE
perf: narrow core Polars feature set

### DIFF
--- a/anndata/Cargo.toml
+++ b/anndata/Cargo.toml
@@ -19,7 +19,20 @@ itertools = "0.14"
 ndarray = "0.17"
 nalgebra-sparse = "0.11"
 num = "0.4"
-polars = { version = "0.53", features = ["lazy", "ndarray", "dtype-full"] }
+# AnnData tables use CSV I/O, lazy concatenation, ndarray conversion, and the
+# scalar dtypes listed below. Avoid Polars's defaults and `dtype-full`: those
+# also enable formatting, temporal/decimal/array types, and other code that the
+# core Rust API never constructs.
+polars = { version = "0.53", default-features = false, features = [
+  "csv",
+  "dtype-categorical",
+  "dtype-i8",
+  "dtype-i16",
+  "dtype-u8",
+  "dtype-u16",
+  "lazy",
+  "ndarray",
+] }
 paste = "1.0"
 parking_lot = "0.12"
 smallvec = "1.15"


### PR DESCRIPTION
## Summary

Replace Polars defaults plus dtype-full with the features used by the core anndata crate.

The retained set covers CSV reading, lazy concatenation, ndarray conversion, categorical values, and the feature-gated 8/16-bit signed and unsigned scalar types supported by AnnData tables. The core crate does not construct Polars temporal, duration, decimal, fixed-array, struct, float16, i128, or u128 columns, and does not need Polars formatting/default bundles.

This keeps existing public data support intact while avoiding unrelated Polars code. The Python crate's separate pyo3-polars dtype requirements are unchanged.

Companion downstream cleanups are COMBINE-lab/grangers#54 and COMBINE-lab/af-anndata#3; the aggregate measurements come from their simpleaf consumer.

## Validation

- all 8 anndata unit tests pass
- all 3 anndata doctests pass
- af-anndata builds and passes its unit tests and doctest against this branch
- in the complete simpleaf graph, this and the companion grangers/af-anndata feature changes remove 10 resolved packages; a controlled clean release build was 13.7% faster, used 11.4% less peak compiler memory, and produced an 11.1% smaller unstripped binary

This is intentionally independent of the open Polars 0.55 update and can be rebased onto it if that lands first.
