### PR TITLE
fix: `obsm` `data frame` have correct indices for python

### DIFF
--- a/anndata-test-utils/Cargo.toml
+++ b/anndata-test-utils/Cargo.toml
@@ -15,6 +15,7 @@ ndarray-rand = "0.16"
 nalgebra = { version = "0.34", features = ["rand"] }
 nalgebra-sparse = "0.11"
 itertools = "0.14"
+polars = { version = "0.53", features = ["lazy", "ndarray", "dtype-full"] }
 
 [dev-dependencies]
 anndata-hdf5 = { version = "0.5.3", path = "../anndata-hdf5" }

--- a/anndata-test-utils/src/lib.rs
+++ b/anndata-test-utils/src/lib.rs
@@ -1,11 +1,14 @@
 mod common;
 pub use common::*;
 
+use anndata::backend::{DataContainer, GroupOp};
 use anndata::concat::{JoinType, concat};
+use anndata::data::{DataFrameIndex, SelectInfoElem};
 use anndata::{data::CsrNonCanonical, *};
 use data::ArrayConvert;
 use nalgebra_sparse::{CooMatrix, CsrMatrix};
 use ndarray::Array2;
+use polars::df;
 use proptest::prelude::*;
 
 pub fn test_basic<B: Backend>() {
@@ -155,6 +158,56 @@ where
             prop_assert_eq!(adata.obsm().get_item::<ArrayData>("test2").unwrap().unwrap(), x);
         }
     });
+}
+
+/// Dataframes stored in obsm/varm must be indexed by the obs/var names, as
+/// polars dataframes carry no index of their own.
+pub fn test_dataframe_index_set_before<B: Backend>() {
+    fn index_on_disk<B: Backend>(path: &std::path::Path, key: &str) -> DataFrameIndex {
+        let store = B::open(path).unwrap();
+        let container = DataContainer::<B>::open(&store.open_group("obsm").unwrap(), key).unwrap();
+        let index = DataFrameElem::<B>::try_from(container)
+            .unwrap()
+            .inner()
+            .index
+            .clone();
+        index
+    }
+
+    with_tmp_dir(|dir| {
+        let names: DataFrameIndex = ["a", "b", "c"].iter().map(|x| x.to_string()).collect();
+        let df = df!("x" => [1i32, 2, 3]).unwrap();
+
+        // Names known before the dataframe is written
+        let path = dir.join("before");
+        let adata = AnnData::<B>::new(&path).unwrap();
+        adata.set_obs_names(names.clone()).unwrap();
+        adata.obsm().add("df", df.clone()).unwrap();
+        adata.close().unwrap();
+        assert_eq!(index_on_disk::<B>(&path, "df"), names);
+
+        // Names set after the dataframe is written
+        let path = dir.join("after");
+        let adata = AnnData::<B>::new(&path).unwrap();
+        adata.obsm().add("df", df.clone()).unwrap();
+        adata.set_obs_names(names.clone()).unwrap();
+        adata.close().unwrap();
+        assert_eq!(index_on_disk::<B>(&path, "df"), names);
+
+        // Subsetting keeps the index in sync
+        let path = dir.join("subset");
+        let adata = AnnData::<B>::new(&path).unwrap();
+        adata.set_obs_names(names.clone()).unwrap();
+        adata.obsm().add("df", df).unwrap();
+        adata
+            .subset([SelectInfoElem::from(vec![0, 2]), SelectInfoElem::full()])
+            .unwrap();
+        adata.close().unwrap();
+        assert_eq!(
+            index_on_disk::<B>(&path, "df").into_vec(),
+            ["a", "c"].map(String::from)
+        );
+    })
 }
 
 pub fn test_concat<B: Backend>() {

--- a/anndata-test-utils/tests/tests.rs
+++ b/anndata-test-utils/tests/tests.rs
@@ -24,6 +24,12 @@ fn test_complex_dataframe() {
 }
 
 #[test]
+fn test_dataframe_index() {
+    utils::test_dataframe_index::<H5>();
+    utils::test_dataframe_index::<Zarr>();
+}
+
+#[test]
 fn test_save() {
     utils::test_save::<H5>();
     utils::test_save::<Zarr>();

--- a/anndata/src/anndata/elem_io.rs
+++ b/anndata/src/anndata/elem_io.rs
@@ -17,13 +17,14 @@ pub(crate) fn open_df<B: Backend>(root: &B::Store, name: &str) -> Result<DataFra
 }
 
 // Helper function to create a new observation matrix (obsm)
+// Dataframes stored in obsm are indexed by the obs names.
 pub(crate) fn open_obsm<B: Backend>(group: B::Group, n_obs: Option<&Dim>) -> Result<AxisArrays<B>> {
-    AxisArrays::new(group, Axis::Row, n_obs, None)
+    AxisArrays::new(group, Axis::Row, n_obs, None, Some("obs"))
 }
 
 // Helper function to create a new pairwise observation matrix (obsp)
 pub(crate) fn open_obsp<B: Backend>(group: B::Group, n_obs: Option<&Dim>) -> Result<AxisArrays<B>> {
-    AxisArrays::new(group, Axis::Pairwise, n_obs, None)
+    AxisArrays::new(group, Axis::Pairwise, n_obs, None, None)
 }
 
 // Helper function to create a new variable matrix (varm)
@@ -31,7 +32,7 @@ pub(crate) fn open_varm<B: Backend>(
     group: B::Group,
     n_vars: Option<&Dim>,
 ) -> Result<AxisArrays<B>> {
-    AxisArrays::new(group, Axis::Row, n_vars, None)
+    AxisArrays::new(group, Axis::Row, n_vars, None, Some("var"))
 }
 
 // Helper function to create a new pairwise variable matrix (varp)
@@ -39,7 +40,7 @@ pub(crate) fn open_varp<B: Backend>(
     group: B::Group,
     n_vars: Option<&Dim>,
 ) -> Result<AxisArrays<B>> {
-    AxisArrays::new(group, Axis::Pairwise, n_vars, None)
+    AxisArrays::new(group, Axis::Pairwise, n_vars, None, None)
 }
 
 // Helper function to create new layers of data
@@ -48,7 +49,7 @@ pub(crate) fn open_layers<B: Backend>(
     n_obs: Option<&Dim>,
     n_vars: Option<&Dim>,
 ) -> Result<AxisArrays<B>> {
-    AxisArrays::new(group, Axis::RowColumn, n_obs, n_vars)
+    AxisArrays::new(group, Axis::RowColumn, n_obs, n_vars, None)
 }
 
 pub(crate) fn new_mapping<G: GroupOp<B>, B: Backend>(store: &G, name: &str) -> Result<B::Group> {

--- a/anndata/src/container/base.rs
+++ b/anndata/src/container/base.rs
@@ -1075,24 +1075,22 @@ where
                 self.current_array += 1;
                 self.next()
             }
+        } else if self.current_position == 0 {
+            // return an empty array
+            self.current_position = 1;
+            Some((
+                self.arrays[0]
+                    .elem
+                    .inner()
+                    .data()
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+                0,
+                0,
+            ))
         } else {
-            if self.current_position == 0 {
-                // return an empty array
-                self.current_position = 1;
-                Some((
-                    self.arrays[0]
-                        .elem
-                        .inner()
-                        .data()
-                        .unwrap()
-                        .try_into()
-                        .unwrap(),
-                    0,
-                    0,
-                ))
-            } else {
-                None
-            }
+            None
         }
     }
 }

--- a/anndata/src/container/base.rs
+++ b/anndata/src/container/base.rs
@@ -245,9 +245,11 @@ impl<B: Backend> InnerDataFrameElem<B> {
     where
         S: AsRef<SelectInfoElem>,
     {
+        // Select before touching the index: reading the dataframe takes its
+        // height from the index stored in the container.
+        let df = self.select(selection)?;
         self.index = self.index.select(selection[0].as_ref());
         self.index.overwrite(&mut self.container)?;
-        let df = self.select(selection)?;
         self.save(df)
     }
 
@@ -447,6 +449,19 @@ impl<B: Backend> InnerArrayElem<B> {
         self.shape = data.shape();
         if self.element.is_some() {
             self.element = Some(data);
+        }
+        Ok(())
+    }
+
+    /// Set the index of a dataframe element. Other data types are left untouched,
+    /// as they do not carry an index.
+    pub(crate) fn set_index(&mut self, index: &DataFrameIndex) -> Result<()> {
+        if let DataType::DataFrame = self.dtype {
+            ensure!(
+                index.len() == self.shape[0],
+                "cannot set index as the lengths differ"
+            );
+            index.overwrite(&mut self.container)?;
         }
         Ok(())
     }

--- a/anndata/src/container/collection.rs
+++ b/anndata/src/container/collection.rs
@@ -1,6 +1,6 @@
 use crate::{
     ElemCollectionOp,
-    backend::{AttributeOp, Backend, GroupOp, iter_containers},
+    backend::{AttributeOp, Backend, DataContainer, GroupOp, iter_containers},
     container::base::*,
     data::*,
 };
@@ -253,6 +253,7 @@ pub struct InnerAxisArrays<B: Backend> {
     container: B::Group,
     dim1: Option<Dim>, // If dim1 is None, mutating AxisArrays is not allowed.
     dim2: Option<Dim>, // If dim2 is None, mutating RowColumn AxisArrays is not allowed.
+    names: Option<&'static str>, // Root dataframe ("obs"/"var") holding the names of the first axis.
     data: HashMap<String, ArrayElem<B>>,
 }
 
@@ -313,10 +314,34 @@ impl<B: Backend> InnerAxisArrays<B> {
         self.dim2.as_ref().expect("Dim2 is not set!")
     }
 
+    /// Names along the first axis, i.e. the index dataframes stored here must have.
+    fn axis_names(&self) -> Result<Option<DataFrameIndex>> {
+        let Some(names) = self.names else {
+            return Ok(None);
+        };
+        let store = self.container.store()?;
+        if !store.exists(names)? {
+            return Ok(None);
+        }
+        let index = DataFrameIndex::read(&DataContainer::<B>::open(&store, names)?)?;
+        Ok((!index.is_empty()).then_some(index))
+    }
+
+    /// Re-index the dataframes stored here with the current axis names.
+    pub(crate) fn update_index(&mut self) -> Result<()> {
+        if let Some(index) = self.axis_names()? {
+            self.data
+                .values()
+                .try_for_each(|x| x.inner().set_index(&index))?;
+        }
+        Ok(())
+    }
+
     pub fn add_data<D: Into<ArrayData>>(&mut self, key: &str, data: D) -> Result<()> {
         // Check if the data is compatible with the current size
         let data = data.into();
         let shape = data.shape();
+        let is_df = matches!(data, ArrayData::DataFrame(_));
         match self.axis {
             Axis::Row => {
                 self.dim1().try_set(shape[0])?;
@@ -341,6 +366,12 @@ impl<B: Backend> InnerAxisArrays<B> {
                 self.insert(key.to_string(), elem);
             }
             Some(elem) => elem.inner().save(data)?,
+        }
+
+        // A polars dataframe carries no index, so stamp the axis names onto the
+        // one that was just written.
+        if is_df && let Some(index) = self.axis_names()? {
+            self.data[key].inner().set_index(&index)?;
         }
         Ok(())
     }
@@ -444,7 +475,7 @@ impl<B: Backend> InnerAxisArrays<B> {
                 }
             }
         }
-        Ok(())
+        self.update_index()
     }
 }
 
@@ -491,6 +522,7 @@ impl<B: Backend> AxisArrays<B> {
         axis: Axis,
         dim1: Option<&Dim>,
         dim2: Option<&Dim>,
+        names: Option<&'static str>,
     ) -> Result<Self> {
         let data: HashMap<_, _> = iter_containers::<B>(&group)
             .map(|(k, v)| (k, ArrayElem::try_from(v).unwrap()))
@@ -535,6 +567,7 @@ impl<B: Backend> AxisArrays<B> {
             container: group,
             dim1: dim1.cloned(),
             dim2: dim2.cloned(),
+            names,
             axis,
             data,
         };

--- a/anndata/src/traits.rs
+++ b/anndata/src/traits.rs
@@ -581,6 +581,12 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
         } else {
             self.obs.inner().set_index(index)?;
         }
+        // Dataframes in obsm are indexed by the obs names.
+        self.obsm
+            .lock()
+            .as_mut()
+            .map(|x| x.update_index())
+            .transpose()?;
         Ok(())
     }
 
@@ -592,6 +598,11 @@ impl<B: Backend> AnnDataOp for AnnData<B> {
         } else {
             self.var.inner().set_index(index)?;
         }
+        self.varm
+            .lock()
+            .as_mut()
+            .map(|x| x.update_index())
+            .transpose()?;
         Ok(())
     }
 

--- a/pyanndata/src/anndata.rs
+++ b/pyanndata/src/anndata.rs
@@ -21,15 +21,13 @@ use std::{
 pub(crate) fn get_backend<P: AsRef<Path>>(filename: P, backend: Option<&str>) -> &str {
     if let Some(backend) = backend {
         backend
-    } else {
-        if let Some(ext) = filename.as_ref().extension() {
-            match ext.to_str().unwrap() {
-                "h5ad" | "h5" | "h5ads" => H5::NAME,
-                _ => H5::NAME,
-            }
-        } else {
-            H5::NAME
+    } else if let Some(ext) = filename.as_ref().extension() {
+        match ext.to_str().unwrap() {
+            "h5ad" | "h5" | "h5ads" => H5::NAME,
+            _ => H5::NAME,
         }
+    } else {
+        H5::NAME
     }
 }
 


### PR DESCRIPTION
There is no specific language around this in our spec (which I just realized) and I did the work already, so I'm going to open this PR but previously, `dataframe`s from this packages (on-disk) in `{obs,var}m` lacked the matching index which would violate our python data structure's internal check: https://github.com/scverse/anndata/blob/01350d5fbea14a257edf3570608f2f0fdcd3883a/src/anndata/_core/aligned_mapping.py#L357-L366. Thus they were rendered unreadable. I need to investigate the history of this now, though.  This is the source of the bug I mentioned in https://github.com/scverse/rustar-aligner/issues/1#issuecomment-5232297955.

UPDATE: This behavior is traced back to https://github.com/scverse/anndata/commit/f47db8c50724f751f0c3943c6c5279ccbd98754d#diff-742a387bf5be7fca99f2c79f893d0a62ca524b6579a14bf5d9db8612ed1ca739R31-R46 with no explanation, so now it's just a matter of how bad breaking that behavior is.